### PR TITLE
Change type of filter property from map[string]string to map[string]any

### DIFF
--- a/examples/cmd/vectorQueryWithFilter/main.go
+++ b/examples/cmd/vectorQueryWithFilter/main.go
@@ -30,7 +30,7 @@ func main() {
 		IndexName: "test-index",
 		ProjectID: "4ce27f9", // use Whoami() to get your project ID
 		ID:        &id,
-		Filter: map[string]any{
+		Filter: request.Filter{
 			"<your field>": map[string][]string{
 				"$in": {"value1", "value2", "value3"},
 			},

--- a/examples/cmd/vectorQueryWithFilter/main.go
+++ b/examples/cmd/vectorQueryWithFilter/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	pineconego "github.com/henomis/pinecone-go"
+	"github.com/henomis/pinecone-go/request"
+	"github.com/henomis/pinecone-go/response"
+)
+
+func main() {
+
+	apiKey := os.Getenv("PINECONE_API_KEY")
+	if apiKey == "" {
+		panic("PINECONE_API_KEY is not set")
+	}
+
+	environment := os.Getenv("PINECONE_ENVIRONMENT")
+	if environment == "" {
+		panic("PINECONE_ENVIRONMENT is not set")
+	}
+
+	p := pineconego.New(environment, apiKey)
+
+	id := "id3"
+	req := &request.VectorQuery{
+		IndexName: "test-index",
+		ProjectID: "4ce27f9", // use Whoami() to get your project ID
+		ID:        &id,
+		Filter: map[string]any{
+			"<your field>": map[string][]string{
+				"$in": {"value1", "value2", "value3"},
+			},
+		},
+		TopK: 10,
+	}
+
+	res := &response.VectorQuery{}
+	err := p.VectorQuery(context.Background(), req, res)
+	if err != nil {
+		panic(err)
+	}
+
+	if !res.IsSuccess() {
+		if res.Response.Code != nil {
+			fmt.Printf("Error: %d -", *res.Response.Code)
+		}
+
+		if res.Response.Message != nil {
+			fmt.Printf(" %s\n", *res.Response.Message)
+		}
+
+		if res.Response.RawBody != nil {
+			fmt.Printf(" %s\n", *res.Response.RawBody)
+		}
+
+		return
+	}
+
+	b, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(b))
+
+}

--- a/request/request.go
+++ b/request/request.go
@@ -1,1 +1,3 @@
 package request
+
+type Filter map[string]any

--- a/request/vectorDelete.go
+++ b/request/vectorDelete.go
@@ -7,12 +7,12 @@ import (
 )
 
 type VectorDelete struct {
-	IndexName string         `json:"-"`
-	ProjectID string         `json:"-"`
-	ID        *string        `json:"id,omitempty"`
-	DeleteAll *bool          `json:"deleteAll,omitempty"`
-	Namespace *string        `json:"namespace,omitempty"`
-	Filter    map[string]any `json:"filter,omitempty"`
+	IndexName string  `json:"-"`
+	ProjectID string  `json:"-"`
+	ID        *string `json:"id,omitempty"`
+	DeleteAll *bool   `json:"deleteAll,omitempty"`
+	Namespace *string `json:"namespace,omitempty"`
+	Filter    Filter  `json:"filter,omitempty"`
 }
 
 func (r *VectorDelete) Path() (string, error) {

--- a/request/vectorDelete.go
+++ b/request/vectorDelete.go
@@ -7,12 +7,12 @@ import (
 )
 
 type VectorDelete struct {
-	IndexName string            `json:"-"`
-	ProjectID string            `json:"-"`
-	ID        *string           `json:"id,omitempty"`
-	DeleteAll *bool             `json:"deleteAll,omitempty"`
-	Namespace *string           `json:"namespace,omitempty"`
-	Filter    map[string]string `json:"filter,omitempty"`
+	IndexName string         `json:"-"`
+	ProjectID string         `json:"-"`
+	ID        *string        `json:"id,omitempty"`
+	DeleteAll *bool          `json:"deleteAll,omitempty"`
+	Namespace *string        `json:"namespace,omitempty"`
+	Filter    map[string]any `json:"filter,omitempty"`
 }
 
 func (r *VectorDelete) Path() (string, error) {

--- a/request/vectorDescribeIndexStats.go
+++ b/request/vectorDescribeIndexStats.go
@@ -7,9 +7,9 @@ import (
 )
 
 type VectorDescribeIndexStats struct {
-	Filter    map[string]any `json:"filter,omitempty"`
-	IndexName string         `json:"-"`
-	ProjectID string         `json:"-"`
+	Filter    Filter `json:"filter,omitempty"`
+	IndexName string `json:"-"`
+	ProjectID string `json:"-"`
 }
 
 func (r *VectorDescribeIndexStats) Path() (string, error) {

--- a/request/vectorDescribeIndexStats.go
+++ b/request/vectorDescribeIndexStats.go
@@ -7,9 +7,9 @@ import (
 )
 
 type VectorDescribeIndexStats struct {
-	Filter    map[string]string `json:"filter,omitempty"`
-	IndexName string            `json:"-"`
-	ProjectID string            `json:"-"`
+	Filter    map[string]any `json:"filter,omitempty"`
+	IndexName string         `json:"-"`
+	ProjectID string         `json:"-"`
 }
 
 func (r *VectorDescribeIndexStats) Path() (string, error) {

--- a/request/vectorQuery.go
+++ b/request/vectorQuery.go
@@ -7,14 +7,14 @@ import (
 )
 
 type VectorQuery struct {
-	ID              *string           `json:"id,omitempty"`
-	Namespace       *string           `json:"namespace,omitempty"`
-	TopK            int32             `json:"topK"`
-	Filter          map[string]string `json:"filter,omitempty"`
-	IncludeValues   *bool             `json:"includeValues,omitempty"`
-	IncludeMetadata *bool             `json:"includeMetadata,omitempty"`
-	Vector          []float64         `json:"vector,omitempty"`
-	SparseVector    []SparseVector    `json:"sparseVector,omitempty"`
+	ID              *string        `json:"id,omitempty"`
+	Namespace       *string        `json:"namespace,omitempty"`
+	TopK            int32          `json:"topK"`
+	Filter          map[string]any `json:"filter,omitempty"`
+	IncludeValues   *bool          `json:"includeValues,omitempty"`
+	IncludeMetadata *bool          `json:"includeMetadata,omitempty"`
+	Vector          []float64      `json:"vector,omitempty"`
+	SparseVector    []SparseVector `json:"sparseVector,omitempty"`
 
 	IndexName string `json:"-"`
 	ProjectID string `json:"-"`

--- a/request/vectorQuery.go
+++ b/request/vectorQuery.go
@@ -10,7 +10,7 @@ type VectorQuery struct {
 	ID              *string        `json:"id,omitempty"`
 	Namespace       *string        `json:"namespace,omitempty"`
 	TopK            int32          `json:"topK"`
-	Filter          map[string]any `json:"filter,omitempty"`
+	Filter          Filter         `json:"filter,omitempty"`
 	IncludeValues   *bool          `json:"includeValues,omitempty"`
 	IncludeMetadata *bool          `json:"includeMetadata,omitempty"`
 	Vector          []float64      `json:"vector,omitempty"`


### PR DESCRIPTION
Filtering based on metadata is a crucial feature of Pinecone when performing search. Right now the type of the filter property is a `map[string]string`. However, most if not all filter operations require a more flexible type (nested maps) than `map[string]string`

For example:
```
{"genre": {"$in":["documentary","action"]}} // => nested map
```

By making the type of the filter more flexible, all filter operations can be supported.

More information about metadata filtering can be found [here](https://docs.pinecone.io/docs/metadata-filtering).

**What has changed?**
- Filter property became more flexible

@henomis what do you think?